### PR TITLE
fix use of deprecated toUpperCase() method

### DIFF
--- a/android/src/main/kotlin/ssk/get_phone_number/CountryToPhonePrefix.kt
+++ b/android/src/main/kotlin/ssk/get_phone_number/CountryToPhonePrefix.kt
@@ -5,7 +5,7 @@ import java.util.*
 internal object CountryToPhonePrefix {
     private val map: MutableMap<String, String> = HashMap()
     fun prefixFor(iso2CountryCode: String): String {
-        return map[iso2CountryCode.toUpperCase()] ?: return ""
+        return map[iso2CountryCode.uppercase()] ?: return ""
     }
 
     init {


### PR DESCRIPTION
kotlin deprecated toUpperCase() in favor of uppercase() some time ago and current gradle versions report the use of the deprecated toUpperCase() as an error, causing any build to fail.